### PR TITLE
Add .env for remote MariaDB configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+DB_HOST=your-mariadb-host
+DB_PORT=3306
+DB_NAME=TemplateDb
+DB_USER=your-user
+DB_PASSWORD=your-password

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ obj/
 *.suo
 *.userprefs
 *.DS_Store
-.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,4 @@
 services:
-  sqlserver:
-    image: mcr.microsoft.com/mssql/server:2022-latest
-    environment:
-      - ACCEPT_EULA=Y
-      - SA_PASSWORD=Your_strong_Passw0rd!
-    ports: ["1433:1433"]
-    volumes: ["sql_data:/var/opt/mssql"]
-
   rabbitmq:
     image: rabbitmq:3-management
     ports: ["5672:5672", "15672:15672"]
@@ -20,14 +12,14 @@ services:
     build:
       context: ./src/TemplateService.Api
       dockerfile: Dockerfile
+    env_file:
+      - .env
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-      - ConnectionStrings__Default=Server=sqlserver,1433;Database=TemplateDb;User Id=sa;Password=Your_strong_Passw0rd;TrustServerCertificate=True
       - RabbitMq__Host=rabbitmq
       - ASPNETCORE_URLS=http://+:8080
       - Otlp__Endpoint=http://jaeger:4317
     depends_on:
-      - sqlserver
       - rabbitmq
       - jaeger
     ports: ["8080:8080"]
@@ -42,5 +34,3 @@ services:
       - template-service
     ports: ["7000:7000"]
 
-volumes:
-  sql_data:

--- a/src/TemplateService.Api/TemplateService.Api.csproj
+++ b/src/TemplateService.Api/TemplateService.Api.csproj
@@ -2,11 +2,11 @@
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.MySql" Version="8.0.1" />
     <PackageReference Include="MassTransit" Version="8.2.3" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />

--- a/src/TemplateService.Infrastructure/TemplateService.Infrastructure.csproj
+++ b/src/TemplateService.Infrastructure/TemplateService.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- add support for MariaDB by using Pomelo EF provider and MySQL health checks
- load connection details from environment variables and supply a `.env` template
- clean docker compose for remote DB and remove SQL Server

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6d7b4e08832f9a9e843aa92fd77e